### PR TITLE
Silent scrolling screenshot implementation

### DIFF
--- a/ScrollStitchUtil.kt
+++ b/ScrollStitchUtil.kt
@@ -1,0 +1,474 @@
+package util
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+
+/**
+ * ScrollStitchUtil
+ *
+ * A single-file utility to estimate vertical overlap between consecutive screenshots
+ * using a coarse-to-fine ZNCC (zero-mean normalized cross-correlation) and to stitch
+ * them into a long image with a softly blended seam. No third-party libraries.
+ *
+ * Assumptions:
+ * - All input bitmaps share the same width (will be enforced; next frames will be scaled to match width).
+ * - Vertical-only motion between frames (typical scroll). Minor local differences are tolerated.
+ */
+object ScrollStitchUtil {
+
+    data class StitchOptions(
+        val pyramidLevels: Int = 3,                 // Coarse-to-fine levels (>=1)
+        val maxSearchPercent: Float = 0.5f,         // Max vertical search range as a fraction of frame height
+        val refineWindowPx: Int = 12,               // Search half-window at finer levels around coarse estimate
+        val sampleXStep: Int = 2,                   // Horizontal sampling stride when computing ZNCC
+        val sampleYStep: Int = 2,                   // Vertical sampling stride when computing ZNCC
+        val cropTopPx: Int = 0,                     // Crop fixed headers before matching
+        val cropBottomPx: Int = 0,                  // Crop fixed footers before matching
+        val minConfidence: Double = 0.25,           // Accept offset only if NCC is above this value
+        val blendBandPx: Int = 24,                  // Seam blending band width
+        val clampOffsetToRange: Boolean = true      // Clamp final offset into [0, height-1]
+    )
+
+    data class OffsetResult(
+        val offsetPx: Int,      // Positive means the content moved up by offset (user scrolled down)
+        val confidence: Double  // NCC score of the best offset [-1, 1]
+    )
+
+    data class StitchResult(
+        val bitmap: Bitmap,
+        val offsets: List<OffsetResult>
+    )
+
+    /**
+     * Stitch a list of frames captured during scrolling.
+     * Uses vertical-only alignment and seam blending at each join.
+     */
+    fun stitch(frames: List<Bitmap>, options: StitchOptions = StitchOptions()): StitchResult {
+        require(frames.isNotEmpty()) { "frames must not be empty" }
+        val normalized = normalizeWidths(frames)
+
+        var result = normalized.first().copy(Bitmap.Config.ARGB_8888, true)
+        val resultCanvas = Canvas(result)
+        val offsets = mutableListOf<OffsetResult>()
+
+        for (i in 1 until normalized.size) {
+            val prev = normalized[i - 1]
+            val next = normalized[i]
+
+            val estimated = estimateVerticalOffset(prev, next, options)
+            offsets += estimated
+
+            val join = computeJoinAndGrow(result, next, estimated, options)
+            result = join
+        }
+
+        return StitchResult(result, offsets)
+    }
+
+    /**
+     * Estimate vertical displacement between two frames using a multi-scale ZNCC search.
+     */
+    fun estimateVerticalOffset(prev: Bitmap, next: Bitmap, options: StitchOptions = StitchOptions()): OffsetResult {
+        val width = prev.width
+        val height = prev.height
+        require(width == next.width) { "Frame widths must match" }
+        require(height == next.height) { "Frame heights must match" }
+
+        val cropTop = options.cropTopPx.coerceAtLeast(0).coerceAtMost(height - 1)
+        val cropBottom = options.cropBottomPx.coerceAtLeast(0).coerceAtMost(height - 1 - cropTop)
+        val effectiveHeight = height - cropTop - cropBottom
+        require(effectiveHeight > 8) { "Effective height after cropping is too small" }
+
+        // Build pyramids (coarsest last)
+        val levels = options.pyramidLevels.coerceAtLeast(1)
+        val prevPyr = buildPyramid(cropBitmap(prev, 0, cropTop, width, effectiveHeight), levels)
+        val nextPyr = buildPyramid(cropBitmap(next, 0, cropTop, width, effectiveHeight), levels)
+
+        // Coarse-to-fine search
+        var bestOffsetAtLevel = 0
+        var bestScoreAtLevel = -2.0
+        var heightAtLevel = prevPyr.last().height
+
+        for (level in levels - 1 downTo 0) {
+            val a = prevPyr[level]
+            val b = nextPyr[level]
+            heightAtLevel = a.height
+
+            val searchRange = if (level == levels - 1) {
+                (heightAtLevel * options.maxSearchPercent).roundToInt()
+            } else {
+                options.refineWindowPx
+            }.coerceAtLeast(1)
+
+            val coarseGuess = if (level == levels - 1) 0 else bestOffsetAtLevel * 2
+            val from = (coarseGuess - searchRange).coerceAtLeast(-(heightAtLevel - 1))
+            val to = (coarseGuess + searchRange).coerceAtMost(heightAtLevel - 1)
+
+            var bestOff = coarseGuess
+            var bestScore = -2.0
+            var secondBest = -2.0
+
+            val grayA = toGrayscaleArray(a)
+            val grayB = toGrayscaleArray(b)
+
+            val stepY = options.sampleYStep.coerceAtLeast(1)
+            val stepX = options.sampleXStep.coerceAtLeast(1)
+
+            for (off in from..to) {
+                val score = znccVerticalShift(grayA, grayB, a.width, a.height, off, stepX, stepY)
+                if (score > bestScore) {
+                    secondBest = bestScore
+                    bestScore = score
+                    bestOff = off
+                } else if (score > secondBest) {
+                    secondBest = score
+                }
+            }
+
+            bestOffsetAtLevel = bestOff
+            bestScoreAtLevel = bestScore
+        }
+
+        // Map offset back to full-res coordinates
+        var finalOffset = bestOffsetAtLevel
+        if (options.clampOffsetToRange) {
+            finalOffset = finalOffset.coerceIn(-(effectiveHeight - 1), (effectiveHeight - 1))
+        }
+
+        // Confidence based on best score (NCC in [-1,1])
+        val confidence = bestScoreAtLevel
+        return OffsetResult(offsetPx = finalOffset, confidence = confidence)
+    }
+
+    // ------------------ internal helpers ------------------
+
+    private fun normalizeWidths(frames: List<Bitmap>): List<Bitmap> {
+        if (frames.size <= 1) return frames
+        val targetWidth = frames.first().width
+        val config = Bitmap.Config.ARGB_8888
+        return frames.mapIndexed { idx, bmp ->
+            if (bmp.width == targetWidth) {
+                if (bmp.config == config && bmp.isMutable) bmp else bmp.copy(config, true)
+            } else {
+                val scaled = Bitmap.createBitmap(targetWidth, (bmp.height * (targetWidth / bmp.width.toFloat())).roundToInt(), config)
+                val canvas = Canvas(scaled)
+                canvas.drawBitmap(Bitmap.createScaledBitmap(bmp, scaled.width, scaled.height, true), 0f, 0f, null)
+                scaled
+            }
+        }
+    }
+
+    private fun cropBitmap(src: Bitmap, x: Int, y: Int, w: Int, h: Int): Bitmap {
+        return Bitmap.createBitmap(src, x, y, w, h)
+    }
+
+    private fun buildPyramid(src: Bitmap, levels: Int): List<Bitmap> {
+        if (levels <= 1) return listOf(src)
+        val pyr = ArrayList<Bitmap>(levels)
+        var cur = src
+        pyr.add(cur)
+        for (i in 1 until levels) {
+            val nextW = max(1, cur.width / 2)
+            val nextH = max(1, cur.height / 2)
+            val down = Bitmap.createScaledBitmap(cur, nextW, nextH, true)
+            pyr.add(down)
+            cur = down
+        }
+        return pyr
+    }
+
+    private fun toGrayscaleArray(bmp: Bitmap): FloatArray {
+        val w = bmp.width
+        val h = bmp.height
+        val pixels = IntArray(w * h)
+        bmp.getPixels(pixels, 0, w, 0, 0, w, h)
+        val gray = FloatArray(w * h)
+        var i = 0
+        while (i < pixels.size) {
+            val c = pixels[i]
+            val r = (c shr 16) and 0xFF
+            val g = (c shr 8) and 0xFF
+            val b = c and 0xFF
+            // luminance (Rec. 601)
+            gray[i] = 0.299f * r + 0.587f * g + 0.114f * b
+            i++
+        }
+        return gray
+    }
+
+    /**
+     * Compute ZNCC score for a vertical shift (off) between two grayscale images of same size.
+     * Only overlapping region contributes. Sampling strides reduce cost.
+     */
+    private fun znccVerticalShift(
+        a: FloatArray,
+        b: FloatArray,
+        width: Int,
+        height: Int,
+        off: Int,
+        stepX: Int,
+        stepY: Int
+    ): Double {
+        if (off == 0) {
+            // full overlap
+            return znccOverlap(a, b, width, height, 0, height, stepX, stepY)
+        }
+        return if (off > 0) {
+            // content moved up by off: compare a[0..h-off) with b[off..h)
+            znccOverlap(a, b, width, height, offStartB = off, overlapH = height - off, stepX = stepX, stepY = stepY)
+        } else {
+            // content moved down by |off|: compare a[|off|..h) with b[0..h-|off|)
+            val p = -off
+            znccOverlapShiftA(a, b, width, height, offStartA = p, overlapH = height - p, stepX = stepX, stepY = stepY)
+        }
+    }
+
+    private fun znccOverlap(
+        a: FloatArray,
+        b: FloatArray,
+        width: Int,
+        height: Int,
+        offStartB: Int,
+        overlapH: Int,
+        stepX: Int,
+        stepY: Int
+    ): Double {
+        if (overlapH <= 4) return -2.0
+        var sumA = 0.0
+        var sumB = 0.0
+        var sumAA = 0.0
+        var sumBB = 0.0
+        var sumAB = 0.0
+        var count = 0
+        val startRowA = 0
+        val startRowB = offStartB
+        val endRowA = overlapH
+        var yA = startRowA
+        var yB = startRowB
+        while (yA < endRowA) {
+            var x = 0
+            val idxA = yA * width
+            val idxB = yB * width
+            while (x < width) {
+                val ia = a[idxA + x].toDouble()
+                val ib = b[idxB + x].toDouble()
+                sumA += ia
+                sumB += ib
+                sumAA += ia * ia
+                sumBB += ib * ib
+                sumAB += ia * ib
+                count++
+                x += stepX
+            }
+            yA += stepY
+            yB += stepY
+        }
+        if (count == 0) return -2.0
+        val meanA = sumA / count
+        val meanB = sumB / count
+        val varA = sumAA / count - meanA.pow(2.0)
+        val varB = sumBB / count - meanB.pow(2.0)
+        val denom = (varA * varB)
+        if (denom <= 1e-6) return -2.0
+        val cov = sumAB / count - meanA * meanB
+        return (cov / kotlin.math.sqrt(denom)).coerceIn(-1.0, 1.0)
+    }
+
+    private fun znccOverlapShiftA(
+        a: FloatArray,
+        b: FloatArray,
+        width: Int,
+        height: Int,
+        offStartA: Int,
+        overlapH: Int,
+        stepX: Int,
+        stepY: Int
+    ): Double {
+        if (overlapH <= 4) return -2.0
+        var sumA = 0.0
+        var sumB = 0.0
+        var sumAA = 0.0
+        var sumBB = 0.0
+        var sumAB = 0.0
+        var count = 0
+        val startRowA = offStartA
+        val startRowB = 0
+        val endRowA = offStartA + overlapH
+        var yA = startRowA
+        var yB = startRowB
+        while (yA < endRowA) {
+            var x = 0
+            val idxA = yA * width
+            val idxB = yB * width
+            while (x < width) {
+                val ia = a[idxA + x].toDouble()
+                val ib = b[idxB + x].toDouble()
+                sumA += ia
+                sumB += ib
+                sumAA += ia * ia
+                sumBB += ib * ib
+                sumAB += ia * ib
+                count++
+                x += stepX
+            }
+            yA += stepY
+            yB += stepY
+        }
+        if (count == 0) return -2.0
+        val meanA = sumA / count
+        val meanB = sumB / count
+        val varA = sumAA / count - meanA.pow(2.0)
+        val varB = sumBB / count - meanB.pow(2.0)
+        val denom = (varA * varB)
+        if (denom <= 1e-6) return -2.0
+        val cov = sumAB / count - meanA * meanB
+        return (cov / kotlin.math.sqrt(denom)).coerceIn(-1.0, 1.0)
+    }
+
+    /**
+     * Compute seam and grow the result by appending the non-overlapping tail of next.
+     * Blends across a small band around the seam.
+     */
+    private fun computeJoinAndGrow(currentResult: Bitmap, next: Bitmap, off: OffsetResult, options: StitchOptions): Bitmap {
+        val width = currentResult.width
+        val height = next.height
+
+        val offset = off.offsetPx.coerceIn(-(height - 1), height - 1)
+
+        // overlap height between last frame (at bottom of currentResult) and next
+        val overlapH = if (offset >= 0) height - offset else height + offset // offset < 0 reduces overlap from top of current
+        val overlapHClamped = overlapH.coerceIn(0, min(height, currentResult.height))
+
+        // y in currentResult where the top of next should align
+        val alignTopYInResult = currentResult.height - overlapHClamped
+
+        // If no overlap (e.g., offset >= height), append directly
+        if (overlapHClamped <= 0) {
+            val grown = Bitmap.createBitmap(width, currentResult.height + height, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(grown)
+            canvas.drawBitmap(currentResult, 0f, 0f, null)
+            canvas.drawBitmap(next, 0f, currentResult.height.toFloat(), null)
+            return grown
+        }
+
+        // Determine optimal seam row within the overlap region by minimal per-row difference
+        val seamRowInOverlap = findSeamRow(currentResult, next, alignTopYInResult, overlapHClamped)
+        val blendBand = options.blendBandPx.coerceAtLeast(0)
+        val seamStartInResult = (alignTopYInResult + seamRowInOverlap - blendBand / 2).coerceIn(0, currentResult.height)
+        val seamEndInResult = (seamStartInResult + blendBand).coerceAtMost(currentResult.height)
+
+        val newHeight = alignTopYInResult + seamRowInOverlap + (height - seamRowInOverlap)
+        val grown = Bitmap.createBitmap(width, max(newHeight, currentResult.height), Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(grown)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+        // 1) draw the existing result entirely
+        canvas.drawBitmap(currentResult, 0f, 0f, null)
+
+        // 2) Blend band
+        if (blendBand > 0 && seamStartInResult < seamEndInResult) {
+            val bandHeight = seamEndInResult - seamStartInResult
+            val tmpRowPrev = IntArray(width)
+            val tmpRowNext = IntArray(width)
+            val blendedRow = IntArray(width)
+            var y = 0
+            while (y < bandHeight) {
+                val alpha = (y.toFloat() / max(1, bandHeight - 1)).coerceIn(0f, 1f)
+                val srcYPrev = seamStartInResult + y
+                val srcYNext = srcYPrev - alignTopYInResult
+                currentResult.getPixels(tmpRowPrev, 0, width, 0, srcYPrev, width, 1)
+                next.getPixels(tmpRowNext, 0, width, 0, srcYNext, width, 1)
+                blendRows(tmpRowPrev, tmpRowNext, alpha, blendedRow)
+                grown.setPixels(blendedRow, 0, width, 0, srcYPrev, width, 1)
+                y++
+            }
+        }
+
+        // 3) Draw the tail of next below the seam band
+        val tailStartInNext = max(0, seamRowInOverlap + (options.blendBandPx + 1) / 2)
+        val destYInResult = alignTopYInResult + tailStartInNext
+        if (tailStartInNext < height && destYInResult < grown.height) {
+            val remainingH = min(height - tailStartInNext, grown.height - destYInResult)
+            if (remainingH > 0) {
+                val tail = Bitmap.createBitmap(next, 0, tailStartInNext, width, remainingH)
+                canvas.drawBitmap(tail, 0f, destYInResult.toFloat(), paint)
+            }
+        }
+
+        return grown
+    }
+
+    private fun findSeamRow(currentResult: Bitmap, next: Bitmap, alignTopYInResult: Int, overlapH: Int): Int {
+        // Evaluate per-row absolute difference on a central vertical strip (to avoid dynamic sidebars)
+        val width = currentResult.width
+        val x0 = (width * 0.1f).roundToInt()
+        val x1 = (width * 0.9f).roundToInt().coerceAtLeast(x0 + 1)
+        val rowPrev = IntArray(x1 - x0)
+        val rowNext = IntArray(x1 - x0)
+
+        var bestRow = 0
+        var bestScore = Double.MAX_VALUE
+        var y = 0
+        while (y < overlapH) {
+            val srcYPrev = alignTopYInResult + y
+            val srcYNext = y
+            currentResult.getPixels(rowPrev, 0, x1 - x0, x0, srcYPrev, x1 - x0, 1)
+            next.getPixels(rowNext, 0, x1 - x0, x0, srcYNext, x1 - x0, 1)
+            var sum = 0L
+            var i = 0
+            while (i < rowPrev.size) {
+                sum += colorDiff(rowPrev[i], rowNext[i])
+                i++
+            }
+            val score = sum.toDouble() / rowPrev.size
+            if (score < bestScore) {
+                bestScore = score
+                bestRow = y
+            }
+            y++
+        }
+        return bestRow
+    }
+
+    private fun colorDiff(a: Int, b: Int): Int {
+        val ra = (a shr 16) and 0xFF
+        val ga = (a shr 8) and 0xFF
+        val ba = a and 0xFF
+        val rb = (b shr 16) and 0xFF
+        val gb = (b shr 8) and 0xFF
+        val bb = b and 0xFF
+        val dr = ra - rb
+        val dg = ga - gb
+        val db = ba - bb
+        return abs(dr) + abs(dg) + abs(db)
+    }
+
+    private fun blendRows(prev: IntArray, next: IntArray, alpha: Float, out: IntArray) {
+        val a = alpha.coerceIn(0f, 1f)
+        val ia = 1f - a
+        var i = 0
+        while (i < prev.size) {
+            val p = prev[i]
+            val n = next[i]
+            val pr = (p shr 16) and 0xFF
+            val pg = (p shr 8) and 0xFF
+            val pb = p and 0xFF
+            val nr = (n shr 16) and 0xFF
+            val ng = (n shr 8) and 0xFF
+            val nb = n and 0xFF
+            val r = (pr * ia + nr * a).roundToInt().coerceIn(0, 255)
+            val g = (pg * ia + ng * a).roundToInt().coerceIn(0, 255)
+            val b = (pb * ia + nb * a).roundToInt().coerceIn(0, 255)
+            out[i] = Color.rgb(r, g, b)
+            i++
+        }
+    }
+}
+

--- a/ScrollStitchUtil.kt
+++ b/ScrollStitchUtil.kt
@@ -1,14 +1,7 @@
-package util
+// Replaced by Java implementation. Keeping file placeholder to avoid build issues if referenced.
+package placeholder
 
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
-import kotlin.math.abs
-import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.pow
-import kotlin.math.roundToInt
+class ScrollStitchUtilKtPlaceholder
 
 /**
  * ScrollStitchUtil

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:name=".CaptureStitchActivity"
+            android:label="Capture & Stitch"
+            android:screenOrientation="portrait"/>
+        <activity
             android:name=".StitchDemoActivity"
             android:label="Stitch Demo"
             android:screenOrientation="portrait" >

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,15 +8,20 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:name=".StitchDemoActivity"
+            android:label="Stitch Demo"
+            android:screenOrientation="portrait" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".DrawerActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
             >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+            
         </activity>
     </application>
 

--- a/app/src/main/java/ch/swissonid/design_lib_sample/CaptureStitchActivity.java
+++ b/app/src/main/java/ch/swissonid/design_lib_sample/CaptureStitchActivity.java
@@ -1,0 +1,244 @@
+package ch.swissonid.design_lib_sample;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.ImageFormat;
+import android.media.Image;
+import android.media.ImageReader;
+import android.media.projection.MediaProjection;
+import android.media.projection.MediaProjectionManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import android.hardware.display.DisplayManager;
+import android.hardware.display.VirtualDisplay;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.swissonid.design_lib_sample.util.ScrollStitchUtil;
+
+public class CaptureStitchActivity extends AppCompatActivity {
+
+    private static final int REQ_CAPTURE = 1001;
+
+    private MediaProjectionManager mpm;
+    private MediaProjection projection;
+    private ImageReader imageReader;
+    private VirtualDisplay virtualDisplay;
+    private HandlerThread imageThread;
+    private Handler imageHandler;
+
+    private ImageView resultImage;
+    private TextView statusText;
+    private ScrollView demoScroll;
+    private Button startBtn;
+
+    private int captureWidth;
+    private int captureHeight;
+    private int captureDensityDpi;
+
+    private final ArrayList<Bitmap> capturedFrames = new ArrayList<>();
+    private volatile int pendingCaptures = 0;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_capture_stitch);
+
+        resultImage = findViewById(R.id.resultImage);
+        statusText = findViewById(R.id.statusText);
+        demoScroll = findViewById(R.id.demoScroll);
+        startBtn = findViewById(R.id.startBtn);
+
+        startBtn.setOnClickListener(v -> startFlow());
+        setupMetrics();
+    }
+
+    private void setupMetrics() {
+        DisplayMetrics dm = new DisplayMetrics();
+        WindowManager wm = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
+        if (wm != null) {
+            Display display = wm.getDefaultDisplay();
+            display.getRealMetrics(dm);
+        } else {
+            dm = getResources().getDisplayMetrics();
+        }
+        captureWidth = dm.widthPixels;
+        captureHeight = dm.heightPixels;
+        captureDensityDpi = dm.densityDpi;
+    }
+
+    private void startFlow() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            statusText.setText("MediaProjection requires API 21+");
+            return;
+        }
+        mpm = (MediaProjectionManager) getSystemService(Context.MEDIA_PROJECTION_SERVICE);
+        if (mpm == null) {
+            statusText.setText("MediaProjectionManager not available");
+            return;
+        }
+        Intent intent = mpm.createScreenCaptureIntent();
+        startActivityForResult(intent, REQ_CAPTURE);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == REQ_CAPTURE) {
+            if (resultCode == RESULT_OK && data != null) {
+                startCapture(resultCode, data);
+            } else {
+                statusText.setText("User denied capture");
+            }
+        }
+    }
+
+    private void startCapture(int resultCode, Intent data) {
+        imageThread = new HandlerThread("image-listener");
+        imageThread.start();
+        imageHandler = new Handler(imageThread.getLooper());
+
+        projection = mpm.getMediaProjection(resultCode, data);
+        imageReader = ImageReader.newInstance(captureWidth, captureHeight, ImageFormat.RGBA_8888, 3);
+        imageReader.setOnImageAvailableListener(reader -> {
+            if (pendingCaptures <= 0) return;
+            Image img = null;
+            try {
+                img = reader.acquireLatestImage();
+                if (img == null) return;
+                Bitmap bmp = imageToBitmap(img);
+                if (bmp != null) {
+                    capturedFrames.add(bmp);
+                    pendingCaptures--;
+                    runOnUiThread(() -> statusText.setText("Captured: " + capturedFrames.size()));
+                }
+            } finally {
+                if (img != null) img.close();
+            }
+        }, imageHandler);
+
+        virtualDisplay = projection.createVirtualDisplay(
+                "cap",
+                captureWidth,
+                captureHeight,
+                captureDensityDpi,
+                DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+                imageReader.getSurface(),
+                null,
+                null
+        );
+
+        runSequence();
+    }
+
+    private void runSequence() {
+        // Scroll the demo ScrollView and capture frames at each step
+        final int steps = 6;
+        final int scrollBy = Math.round(captureHeight * 0.35f);
+        capturedFrames.clear();
+        statusText.setText("Capturing...");
+
+        Handler ui = new Handler(getMainLooper());
+        long t = 300; // initial delay to stabilize
+        for (int i = 0; i < steps; i++) {
+            final int stepIndex = i;
+            ui.postDelayed(() -> {
+                demoScroll.smoothScrollBy(0, scrollBy);
+            }, t);
+            t += 450; // allow scroll animation
+            ui.postDelayed(() -> requestOneCapture(), t);
+            t += 350; // allow capture
+        }
+        // After last capture, stitch
+        ui.postDelayed(this::finishAndStitch, t + 200);
+    }
+
+    private void requestOneCapture() {
+        pendingCaptures++;
+    }
+
+    private void finishAndStitch() {
+        stopCapture();
+        if (capturedFrames.isEmpty()) {
+            statusText.setText("No frames captured");
+            return;
+        }
+        ScrollStitchUtil.StitchOptions opts = new ScrollStitchUtil.StitchOptions();
+        opts.pyramidLevels = 3;
+        opts.maxSearchPercent = 0.45f;
+        opts.refineWindowPx = 12;
+        opts.sampleXStep = 2;
+        opts.sampleYStep = 2;
+        opts.blendBandPx = 28;
+        opts.cropTopPx = Math.round(captureHeight * 0.08f); // likely status/action bar
+        opts.cropBottomPx = 0;
+
+        ScrollStitchUtil.StitchResult sr = ScrollStitchUtil.stitch(capturedFrames, opts);
+        resultImage.setImageBitmap(sr.bitmap);
+        StringBuilder sb = new StringBuilder();
+        sb.append("Frames: ").append(capturedFrames.size()).append("\n");
+        for (ScrollStitchUtil.OffsetResult o : sr.offsets) {
+            sb.append(o.offsetPx).append(", ").append(String.format("%.3f", o.confidence)).append("\n");
+        }
+        statusText.setText(sb.toString());
+    }
+
+    private void stopCapture() {
+        if (virtualDisplay != null) {
+            virtualDisplay.release();
+            virtualDisplay = null;
+        }
+        if (imageReader != null) {
+            imageReader.close();
+            imageReader = null;
+        }
+        if (projection != null) {
+            projection.stop();
+            projection = null;
+        }
+        if (imageThread != null) {
+            imageThread.quitSafely();
+            imageThread = null;
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        stopCapture();
+    }
+
+    private Bitmap imageToBitmap(Image image) {
+        Image.Plane[] planes = image.getPlanes();
+        if (planes == null || planes.length == 0) return null;
+        Image.Plane plane = planes[0];
+        int pixelStride = plane.getPixelStride();
+        int rowStride = plane.getRowStride();
+        int rowPadding = rowStride - pixelStride * captureWidth;
+        Bitmap bmp = Bitmap.createBitmap(captureWidth + rowPadding / pixelStride, captureHeight, Bitmap.Config.ARGB_8888);
+        ByteBuffer buffer = plane.getBuffer();
+        bmp.copyPixelsFromBuffer(buffer);
+        if (bmp.getWidth() != captureWidth) {
+            Bitmap cropped = Bitmap.createBitmap(bmp, 0, 0, captureWidth, captureHeight);
+            bmp.recycle();
+            return cropped;
+        }
+        return bmp;
+    }
+}
+

--- a/app/src/main/java/ch/swissonid/design_lib_sample/StitchDemoActivity.java
+++ b/app/src/main/java/ch/swissonid/design_lib_sample/StitchDemoActivity.java
@@ -5,12 +5,11 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
 import android.widget.ImageView;
 import android.widget.ScrollView;
 import android.widget.TextView;
-
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/ch/swissonid/design_lib_sample/StitchDemoActivity.java
+++ b/app/src/main/java/ch/swissonid/design_lib_sample/StitchDemoActivity.java
@@ -1,0 +1,90 @@
+package ch.swissonid.design_lib_sample;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.os.Bundle;
+import android.widget.ImageView;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.swissonid.design_lib_sample.util.ScrollStitchUtil;
+
+public class StitchDemoActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_stitch_demo);
+
+        ImageView iv = findViewById(R.id.resultImage);
+        TextView tv = findViewById(R.id.debugText);
+
+        List<Bitmap> frames = synthesizeFrames(1080, 1600, 6, 240); // width, height, count, scrollStep
+        ScrollStitchUtil.StitchOptions opts = new ScrollStitchUtil.StitchOptions();
+        opts.pyramidLevels = 3;
+        opts.maxSearchPercent = 0.45f;
+        opts.refineWindowPx = 12;
+        opts.sampleXStep = 2;
+        opts.sampleYStep = 2;
+        opts.blendBandPx = 28;
+        opts.cropTopPx = 80; // 模拟固定头部
+        opts.cropBottomPx = 0;
+
+        ScrollStitchUtil.StitchResult sr = ScrollStitchUtil.stitch(frames, opts);
+        iv.setImageBitmap(sr.bitmap);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Offsets (px), NCC: \n");
+        for (ScrollStitchUtil.OffsetResult o : sr.offsets) {
+            sb.append(o.offsetPx).append(", ").append(String.format("%.3f", o.confidence)).append("\n");
+        }
+        tv.setText(sb.toString());
+    }
+
+    private List<Bitmap> synthesizeFrames(int width, int height, int count, int scrollStep) {
+        // 生成一个高于屏幕的长内容，然后按 scrollStep 向上切割模拟滚动截屏
+        int contentHeight = height + (count - 1) * scrollStep + 200;
+        Bitmap longContent = Bitmap.createBitmap(width, contentHeight, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(longContent);
+        Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+        // 背景渐变条纹
+        for (int y = 0; y < contentHeight; y += 40) {
+            int c = Color.rgb((y * 3) % 256, (y * 7) % 256, (y * 11) % 256);
+            p.setColor(c);
+            canvas.drawRect(0, y, width, y + 40, p);
+        }
+        // 固定头部（模拟悬浮栏）
+        p.setColor(Color.argb(220, 30, 30, 30));
+        canvas.drawRect(0, 0, width, 80, p);
+        p.setColor(Color.WHITE);
+        p.setTextSize(48f);
+        canvas.drawText("Fixed Header", 24, 56, p);
+        // 插入一些图形与文字
+        p.setTextSize(36f);
+        for (int i = 0; i < 50; i++) {
+            int y = 120 + i * 100;
+            p.setColor(Color.WHITE);
+            canvas.drawText("Row " + (i + 1) + " — Lorem ipsum dolor sit amet.", 24, y, p);
+            p.setColor(Color.argb(160, (i * 23) % 255, (i * 53) % 255, (i * 83) % 255));
+            canvas.drawRect(24, y + 20, width - 24, y + 60, p);
+        }
+
+        ArrayList<Bitmap> frames = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            int top = i * scrollStep;
+            if (top + height > contentHeight) top = contentHeight - height;
+            Bitmap frame = Bitmap.createBitmap(longContent, 0, top, width, height);
+            frames.add(frame);
+        }
+        return frames;
+    }
+}
+

--- a/app/src/main/java/ch/swissonid/design_lib_sample/util/ScrollStitchUtil.java
+++ b/app/src/main/java/ch/swissonid/design_lib_sample/util/ScrollStitchUtil.java
@@ -1,0 +1,344 @@
+package ch.swissonid.design_lib_sample.util;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ScrollStitchUtil (Java)
+ * Vertical-only alignment and stitching of scrolling screenshots using
+ * multi-scale ZNCC search and seam blending. No third-party dependencies.
+ */
+public final class ScrollStitchUtil {
+
+    private ScrollStitchUtil() {}
+
+    public static final class StitchOptions {
+        public int pyramidLevels = 3;
+        public float maxSearchPercent = 0.5f;
+        public int refineWindowPx = 12;
+        public int sampleXStep = 2;
+        public int sampleYStep = 2;
+        public int cropTopPx = 0;
+        public int cropBottomPx = 0;
+        public double minConfidence = 0.25;
+        public int blendBandPx = 24;
+        public boolean clampOffsetToRange = true;
+    }
+
+    public static final class OffsetResult {
+        public final int offsetPx;
+        public final double confidence;
+        public OffsetResult(int offsetPx, double confidence) {
+            this.offsetPx = offsetPx;
+            this.confidence = confidence;
+        }
+    }
+
+    public static final class StitchResult {
+        public final Bitmap bitmap;
+        public final List<OffsetResult> offsets;
+        public StitchResult(Bitmap bitmap, List<OffsetResult> offsets) {
+            this.bitmap = bitmap;
+            this.offsets = offsets;
+        }
+    }
+
+    public static StitchResult stitch(List<Bitmap> frames, StitchOptions options) {
+        if (frames == null || frames.isEmpty()) throw new IllegalArgumentException("frames empty");
+        if (options == null) options = new StitchOptions();
+        List<Bitmap> normalized = normalizeWidths(frames);
+        Bitmap result = normalized.get(0).copy(Bitmap.Config.ARGB_8888, true);
+        Canvas canvas = new Canvas(result);
+        List<OffsetResult> offsets = new ArrayList<>();
+        for (int i = 1; i < normalized.size(); i++) {
+            Bitmap prev = normalized.get(i - 1);
+            Bitmap next = normalized.get(i);
+            OffsetResult est = estimateVerticalOffset(prev, next, options);
+            offsets.add(est);
+            result = computeJoinAndGrow(result, next, est, options);
+            canvas = new Canvas(result);
+        }
+        return new StitchResult(result, offsets);
+    }
+
+    public static OffsetResult estimateVerticalOffset(Bitmap prev, Bitmap next, StitchOptions options) {
+        int width = prev.getWidth();
+        int height = prev.getHeight();
+        if (width != next.getWidth() || height != next.getHeight()) throw new IllegalArgumentException("dimension mismatch");
+        int cropTop = clamp(options.cropTopPx, 0, height - 1);
+        int cropBottom = clamp(options.cropBottomPx, 0, height - 1 - cropTop);
+        int effectiveHeight = height - cropTop - cropBottom;
+        if (effectiveHeight <= 8) throw new IllegalArgumentException("effective height too small");
+        int levels = Math.max(1, options.pyramidLevels);
+        Bitmap prevCrop = Bitmap.createBitmap(prev, 0, cropTop, width, effectiveHeight);
+        Bitmap nextCrop = Bitmap.createBitmap(next, 0, cropTop, width, effectiveHeight);
+        List<Bitmap> prevPyr = buildPyramid(prevCrop, levels);
+        List<Bitmap> nextPyr = buildPyramid(nextCrop, levels);
+        int bestOffsetAtLevel = 0;
+        double bestScoreAtLevel = -2.0;
+        for (int level = levels - 1; level >= 0; level--) {
+            Bitmap a = prevPyr.get(level);
+            Bitmap b = nextPyr.get(level);
+            int h = a.getHeight();
+            int w = a.getWidth();
+            int searchRange = (level == levels - 1)
+                    ? Math.max(1, Math.round(h * options.maxSearchPercent))
+                    : Math.max(1, options.refineWindowPx);
+            int coarseGuess = (level == levels - 1) ? 0 : bestOffsetAtLevel * 2;
+            int from = Math.max(-(h - 1), coarseGuess - searchRange);
+            int to = Math.min(h - 1, coarseGuess + searchRange);
+            float[] grayA = toGrayscaleArray(a);
+            float[] grayB = toGrayscaleArray(b);
+            int stepX = Math.max(1, options.sampleXStep);
+            int stepY = Math.max(1, options.sampleYStep);
+            double bestScore = -2.0;
+            double secondBest = -2.0;
+            int bestOff = coarseGuess;
+            for (int off = from; off <= to; off++) {
+                double score = znccVerticalShift(grayA, grayB, w, h, off, stepX, stepY);
+                if (score > bestScore) {
+                    secondBest = bestScore;
+                    bestScore = score;
+                    bestOff = off;
+                } else if (score > secondBest) {
+                    secondBest = score;
+                }
+            }
+            bestOffsetAtLevel = bestOff;
+            bestScoreAtLevel = bestScore;
+        }
+        int finalOffset = bestOffsetAtLevel;
+        if (options.clampOffsetToRange) finalOffset = clamp(finalOffset, -(effectiveHeight - 1), (effectiveHeight - 1));
+        return new OffsetResult(finalOffset, bestScoreAtLevel);
+    }
+
+    private static List<Bitmap> normalizeWidths(List<Bitmap> frames) {
+        if (frames.size() <= 1) return frames;
+        int targetWidth = frames.get(0).getWidth();
+        List<Bitmap> out = new ArrayList<>(frames.size());
+        for (Bitmap bmp : frames) {
+            if (bmp.getWidth() == targetWidth && bmp.getConfig() == Bitmap.Config.ARGB_8888 && bmp.isMutable()) {
+                out.add(bmp);
+            } else if (bmp.getWidth() == targetWidth) {
+                out.add(bmp.copy(Bitmap.Config.ARGB_8888, true));
+            } else {
+                int scaledH = Math.round(bmp.getHeight() * (targetWidth / (float) bmp.getWidth()));
+                Bitmap scaled = Bitmap.createScaledBitmap(bmp, targetWidth, scaledH, true);
+                out.add(scaled.copy(Bitmap.Config.ARGB_8888, true));
+            }
+        }
+        return out;
+    }
+
+    private static List<Bitmap> buildPyramid(Bitmap src, int levels) {
+        ArrayList<Bitmap> pyr = new ArrayList<>(levels);
+        Bitmap cur = src;
+        pyr.add(cur);
+        for (int i = 1; i < levels; i++) {
+            int nextW = Math.max(1, cur.getWidth() / 2);
+            int nextH = Math.max(1, cur.getHeight() / 2);
+            Bitmap down = Bitmap.createScaledBitmap(cur, nextW, nextH, true);
+            pyr.add(down);
+            cur = down;
+        }
+        return pyr;
+    }
+
+    private static float[] toGrayscaleArray(Bitmap bmp) {
+        int w = bmp.getWidth();
+        int h = bmp.getHeight();
+        int[] pixels = new int[w * h];
+        bmp.getPixels(pixels, 0, w, 0, 0, w, h);
+        float[] gray = new float[pixels.length];
+        for (int i = 0; i < pixels.length; i++) {
+            int c = pixels[i];
+            int r = (c >> 16) & 0xFF;
+            int g = (c >> 8) & 0xFF;
+            int b = c & 0xFF;
+            gray[i] = 0.299f * r + 0.587f * g + 0.114f * b;
+        }
+        return gray;
+    }
+
+    private static double znccVerticalShift(float[] a, float[] b, int width, int height, int off, int stepX, int stepY) {
+        if (off == 0) return znccOverlap(a, b, width, height, 0, height, stepX, stepY);
+        if (off > 0) return znccOverlap(a, b, width, height, off, height - off, stepX, stepY);
+        int p = -off;
+        return znccOverlapShiftA(a, b, width, height, p, height - p, stepX, stepY);
+    }
+
+    private static double znccOverlap(float[] a, float[] b, int width, int height, int offStartB, int overlapH, int stepX, int stepY) {
+        if (overlapH <= 4) return -2.0;
+        double sumA = 0, sumB = 0, sumAA = 0, sumBB = 0, sumAB = 0;
+        int count = 0;
+        int startRowA = 0;
+        int startRowB = offStartB;
+        int endRowA = overlapH;
+        for (int yA = startRowA, yB = startRowB; yA < endRowA; yA += stepY, yB += stepY) {
+            int idxA = yA * width;
+            int idxB = yB * width;
+            for (int x = 0; x < width; x += stepX) {
+                double ia = a[idxA + x];
+                double ib = b[idxB + x];
+                sumA += ia;
+                sumB += ib;
+                sumAA += ia * ia;
+                sumBB += ib * ib;
+                sumAB += ia * ib;
+                count++;
+            }
+        }
+        if (count == 0) return -2.0;
+        double meanA = sumA / count;
+        double meanB = sumB / count;
+        double varA = sumAA / count - meanA * meanA;
+        double varB = sumBB / count - meanB * meanB;
+        double denom = varA * varB;
+        if (denom <= 1e-6) return -2.0;
+        double cov = (sumAB / count) - meanA * meanB;
+        double ncc = cov / Math.sqrt(denom);
+        if (ncc > 1.0) ncc = 1.0; else if (ncc < -1.0) ncc = -1.0;
+        return ncc;
+    }
+
+    private static double znccOverlapShiftA(float[] a, float[] b, int width, int height, int offStartA, int overlapH, int stepX, int stepY) {
+        if (overlapH <= 4) return -2.0;
+        double sumA = 0, sumB = 0, sumAA = 0, sumBB = 0, sumAB = 0;
+        int count = 0;
+        int startRowA = offStartA;
+        int startRowB = 0;
+        int endRowA = offStartA + overlapH;
+        for (int yA = startRowA, yB = startRowB; yA < endRowA; yA += stepY, yB += stepY) {
+            int idxA = yA * width;
+            int idxB = yB * width;
+            for (int x = 0; x < width; x += stepX) {
+                double ia = a[idxA + x];
+                double ib = b[idxB + x];
+                sumA += ia;
+                sumB += ib;
+                sumAA += ia * ia;
+                sumBB += ib * ib;
+                sumAB += ia * ib;
+                count++;
+            }
+        }
+        if (count == 0) return -2.0;
+        double meanA = sumA / count;
+        double meanB = sumB / count;
+        double varA = sumAA / count - meanA * meanA;
+        double varB = sumBB / count - meanB * meanB;
+        double denom = varA * varB;
+        if (denom <= 1e-6) return -2.0;
+        double cov = (sumAB / count) - meanA * meanB;
+        double ncc = cov / Math.sqrt(denom);
+        if (ncc > 1.0) ncc = 1.0; else if (ncc < -1.0) ncc = -1.0;
+        return ncc;
+    }
+
+    private static Bitmap computeJoinAndGrow(Bitmap currentResult, Bitmap next, OffsetResult off, StitchOptions options) {
+        int width = currentResult.getWidth();
+        int height = next.getHeight();
+        int offset = clamp(off.offsetPx, -(height - 1), height - 1);
+        int overlapH = (offset >= 0) ? height - offset : height + offset;
+        overlapH = clamp(overlapH, 0, Math.min(height, currentResult.getHeight()));
+        int alignTopYInResult = currentResult.getHeight() - overlapH;
+        if (overlapH <= 0) {
+            Bitmap grown = Bitmap.createBitmap(width, currentResult.getHeight() + height, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(grown);
+            canvas.drawBitmap(currentResult, 0, 0, null);
+            canvas.drawBitmap(next, 0, currentResult.getHeight(), null);
+            return grown;
+        }
+        int seamRowInOverlap = findSeamRow(currentResult, next, alignTopYInResult, overlapH);
+        int blendBand = Math.max(0, options.blendBandPx);
+        int seamStartInResult = clamp(alignTopYInResult + seamRowInOverlap - blendBand / 2, 0, currentResult.getHeight());
+        int seamEndInResult = clamp(seamStartInResult + blendBand, 0, currentResult.getHeight());
+        int newHeight = Math.max(currentResult.getHeight(), alignTopYInResult + seamRowInOverlap + (height - seamRowInOverlap));
+        Bitmap grown = Bitmap.createBitmap(width, newHeight, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(grown);
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        canvas.drawBitmap(currentResult, 0, 0, null);
+        if (blendBand > 0 && seamStartInResult < seamEndInResult) {
+            int bandHeight = seamEndInResult - seamStartInResult;
+            int[] rowPrev = new int[width];
+            int[] rowNext = new int[width];
+            int[] blended = new int[width];
+            for (int y = 0; y < bandHeight; y++) {
+                float alpha = bandHeight <= 1 ? 1f : (y / (float) (bandHeight - 1));
+                int srcYPrev = seamStartInResult + y;
+                int srcYNext = srcYPrev - alignTopYInResult;
+                currentResult.getPixels(rowPrev, 0, width, 0, srcYPrev, width, 1);
+                next.getPixels(rowNext, 0, width, 0, srcYNext, width, 1);
+                blendRows(rowPrev, rowNext, alpha, blended);
+                grown.setPixels(blended, 0, width, 0, srcYPrev, width, 1);
+            }
+        }
+        int tailStartInNext = Math.max(0, seamRowInOverlap + (blendBand + 1) / 2);
+        int destYInResult = alignTopYInResult + tailStartInNext;
+        if (tailStartInNext < height && destYInResult < grown.getHeight()) {
+            int remainingH = Math.min(height - tailStartInNext, grown.getHeight() - destYInResult);
+            if (remainingH > 0) {
+                Bitmap tail = Bitmap.createBitmap(next, 0, tailStartInNext, width, remainingH);
+                canvas.drawBitmap(tail, 0, destYInResult, paint);
+            }
+        }
+        return grown;
+    }
+
+    private static int findSeamRow(Bitmap currentResult, Bitmap next, int alignTopYInResult, int overlapH) {
+        int width = currentResult.getWidth();
+        int x0 = Math.round(width * 0.1f);
+        int x1 = Math.max(x0 + 1, Math.round(width * 0.9f));
+        int[] rowPrev = new int[x1 - x0];
+        int[] rowNext = new int[x1 - x0];
+        long bestScore = Long.MAX_VALUE;
+        int bestRow = 0;
+        for (int y = 0; y < overlapH; y++) {
+            int srcYPrev = alignTopYInResult + y;
+            int srcYNext = y;
+            currentResult.getPixels(rowPrev, 0, x1 - x0, x0, srcYPrev, x1 - x0, 1);
+            next.getPixels(rowNext, 0, x1 - x0, x0, srcYNext, x1 - x0, 1);
+            long sum = 0L;
+            for (int i = 0; i < rowPrev.length; i++) sum += colorDiff(rowPrev[i], rowNext[i]);
+            if (sum < bestScore) { bestScore = sum; bestRow = y; }
+        }
+        return bestRow;
+    }
+
+    private static int colorDiff(int a, int b) {
+        int ra = (a >> 16) & 0xFF;
+        int ga = (a >> 8) & 0xFF;
+        int ba = a & 0xFF;
+        int rb = (b >> 16) & 0xFF;
+        int gb = (b >> 8) & 0xFF;
+        int bb = b & 0xFF;
+        return Math.abs(ra - rb) + Math.abs(ga - gb) + Math.abs(ba - bb);
+    }
+
+    private static void blendRows(int[] prev, int[] next, float alpha, int[] out) {
+        float a = Math.max(0f, Math.min(1f, alpha));
+        float ia = 1f - a;
+        for (int i = 0; i < prev.length; i++) {
+            int p = prev[i];
+            int n = next[i];
+            int pr = (p >> 16) & 0xFF;
+            int pg = (p >> 8) & 0xFF;
+            int pb = p & 0xFF;
+            int nr = (n >> 16) & 0xFF;
+            int ng = (n >> 8) & 0xFF;
+            int nb = n & 0xFF;
+            int r = clamp(Math.round(pr * ia + nr * a), 0, 255);
+            int g = clamp(Math.round(pg * ia + ng * a), 0, 255);
+            int b = clamp(Math.round(pb * ia + nb * a), 0, 255);
+            out[i] = Color.rgb(r, g, b);
+        }
+    }
+
+    private static int clamp(int v, int lo, int hi) { return Math.max(lo, Math.min(hi, v)); }
+}
+

--- a/app/src/main/res/layout/activity_capture_stitch.xml
+++ b/app/src/main/res/layout/activity_capture_stitch.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="12dp">
+
+    <Button
+        android:id="@+id/startBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start Capture & Stitch"/>
+
+    <TextView
+        android:id="@+id/statusText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:textColor="#333333"
+        android:paddingTop="8dp"
+        android:text="Ready"/>
+
+    <ScrollView
+        android:id="@+id/demoScroll"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:background="#EEEEEE"
+        android:padding="8dp"
+        android:layout_marginTop="8dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Scroll area (for demo)"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nPhasellus blandit."/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 1"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 2"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 3"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 4"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 5"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 6"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 7"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 8"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 9"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 10"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 11"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Item 12"/>
+
+        </LinearLayout>
+    </ScrollView>
+
+    <ImageView
+        android:id="@+id/resultImage"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:adjustViewBounds="true"
+        android:scaleType="fitCenter"/>
+
+</LinearLayout>
+

--- a/app/src/main/res/layout/activity_stitch_demo.xml
+++ b/app/src/main/res/layout/activity_stitch_demo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/debugText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="#333333"
+            android:textSize="14sp"
+            android:text="Debug" />
+
+        <ImageView
+            android:id="@+id/resultImage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:contentDescription="stitched" />
+
+    </LinearLayout>
+</ScrollView>
+

--- a/src/main/java/util/ScrollStitchUtil.java
+++ b/src/main/java/util/ScrollStitchUtil.java
@@ -1,0 +1,382 @@
+package util;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ScrollStitchUtil (Java)
+ *
+ * Vertical-only alignment and stitching of scrolling screenshots using
+ * multi-scale ZNCC search and seam blending. No third-party dependencies.
+ */
+public final class ScrollStitchUtil {
+
+    private ScrollStitchUtil() {}
+
+    public static final class StitchOptions {
+        public int pyramidLevels = 3;       // >= 1
+        public float maxSearchPercent = 0.5f;
+        public int refineWindowPx = 12;
+        public int sampleXStep = 2;
+        public int sampleYStep = 2;
+        public int cropTopPx = 0;
+        public int cropBottomPx = 0;
+        public double minConfidence = 0.25;
+        public int blendBandPx = 24;
+        public boolean clampOffsetToRange = true;
+    }
+
+    public static final class OffsetResult {
+        public final int offsetPx;
+        public final double confidence; // NCC score
+        public OffsetResult(int offsetPx, double confidence) {
+            this.offsetPx = offsetPx;
+            this.confidence = confidence;
+        }
+    }
+
+    public static final class StitchResult {
+        public final Bitmap bitmap;
+        public final List<OffsetResult> offsets;
+        public StitchResult(Bitmap bitmap, List<OffsetResult> offsets) {
+            this.bitmap = bitmap;
+            this.offsets = offsets;
+        }
+    }
+
+    public static StitchResult stitch(List<Bitmap> frames, StitchOptions options) {
+        if (frames == null || frames.isEmpty()) throw new IllegalArgumentException("frames empty");
+        if (options == null) options = new StitchOptions();
+
+        List<Bitmap> normalized = normalizeWidths(frames);
+        Bitmap result = normalized.get(0).copy(Bitmap.Config.ARGB_8888, true);
+        Canvas canvas = new Canvas(result);
+        List<OffsetResult> offsets = new ArrayList<>();
+
+        for (int i = 1; i < normalized.size(); i++) {
+            Bitmap prev = normalized.get(i - 1);
+            Bitmap next = normalized.get(i);
+            OffsetResult est = estimateVerticalOffset(prev, next, options);
+            offsets.add(est);
+            result = computeJoinAndGrow(result, next, est, options);
+            canvas = new Canvas(result);
+        }
+        return new StitchResult(result, offsets);
+    }
+
+    public static OffsetResult estimateVerticalOffset(Bitmap prev, Bitmap next, StitchOptions options) {
+        int width = prev.getWidth();
+        int height = prev.getHeight();
+        if (width != next.getWidth() || height != next.getHeight()) {
+            throw new IllegalArgumentException("dimension mismatch");
+        }
+
+        int cropTop = clamp(options.cropTopPx, 0, height - 1);
+        int cropBottom = clamp(options.cropBottomPx, 0, height - 1 - cropTop);
+        int effectiveHeight = height - cropTop - cropBottom;
+        if (effectiveHeight <= 8) throw new IllegalArgumentException("effective height too small");
+
+        int levels = Math.max(1, options.pyramidLevels);
+        Bitmap prevCrop = Bitmap.createBitmap(prev, 0, cropTop, width, effectiveHeight);
+        Bitmap nextCrop = Bitmap.createBitmap(next, 0, cropTop, width, effectiveHeight);
+        List<Bitmap> prevPyr = buildPyramid(prevCrop, levels);
+        List<Bitmap> nextPyr = buildPyramid(nextCrop, levels);
+
+        int bestOffsetAtLevel = 0;
+        double bestScoreAtLevel = -2.0;
+
+        for (int level = levels - 1; level >= 0; level--) {
+            Bitmap a = prevPyr.get(level);
+            Bitmap b = nextPyr.get(level);
+            int h = a.getHeight();
+            int w = a.getWidth();
+            int searchRange = (level == levels - 1)
+                    ? Math.max(1, Math.round(h * options.maxSearchPercent))
+                    : Math.max(1, options.refineWindowPx);
+            int coarseGuess = (level == levels - 1) ? 0 : bestOffsetAtLevel * 2;
+            int from = Math.max(-(h - 1), coarseGuess - searchRange);
+            int to = Math.min(h - 1, coarseGuess + searchRange);
+
+            float[] grayA = toGrayscaleArray(a);
+            float[] grayB = toGrayscaleArray(b);
+            int stepX = Math.max(1, options.sampleXStep);
+            int stepY = Math.max(1, options.sampleYStep);
+
+            double bestScore = -2.0;
+            double secondBest = -2.0;
+            int bestOff = coarseGuess;
+            for (int off = from; off <= to; off++) {
+                double score = znccVerticalShift(grayA, grayB, w, h, off, stepX, stepY);
+                if (score > bestScore) {
+                    secondBest = bestScore;
+                    bestScore = score;
+                    bestOff = off;
+                } else if (score > secondBest) {
+                    secondBest = score;
+                }
+            }
+            bestOffsetAtLevel = bestOff;
+            bestScoreAtLevel = bestScore;
+        }
+
+        int finalOffset = bestOffsetAtLevel;
+        if (options.clampOffsetToRange) {
+            finalOffset = clamp(finalOffset, -(effectiveHeight - 1), (effectiveHeight - 1));
+        }
+        return new OffsetResult(finalOffset, bestScoreAtLevel);
+    }
+
+    private static List<Bitmap> normalizeWidths(List<Bitmap> frames) {
+        if (frames.size() <= 1) return frames;
+        int targetWidth = frames.get(0).getWidth();
+        List<Bitmap> out = new ArrayList<>(frames.size());
+        for (Bitmap bmp : frames) {
+            if (bmp.getWidth() == targetWidth && bmp.getConfig() == Bitmap.Config.ARGB_8888 && bmp.isMutable()) {
+                out.add(bmp);
+            } else if (bmp.getWidth() == targetWidth) {
+                out.add(bmp.copy(Bitmap.Config.ARGB_8888, true));
+            } else {
+                int scaledH = Math.round(bmp.getHeight() * (targetWidth / (float) bmp.getWidth()));
+                Bitmap scaled = Bitmap.createScaledBitmap(bmp, targetWidth, scaledH, true);
+                out.add(scaled.copy(Bitmap.Config.ARGB_8888, true));
+            }
+        }
+        return out;
+    }
+
+    private static List<Bitmap> buildPyramid(Bitmap src, int levels) {
+        ArrayList<Bitmap> pyr = new ArrayList<>(levels);
+        Bitmap cur = src;
+        pyr.add(cur);
+        for (int i = 1; i < levels; i++) {
+            int nextW = Math.max(1, cur.getWidth() / 2);
+            int nextH = Math.max(1, cur.getHeight() / 2);
+            Bitmap down = Bitmap.createScaledBitmap(cur, nextW, nextH, true);
+            pyr.add(down);
+            cur = down;
+        }
+        return pyr;
+    }
+
+    private static float[] toGrayscaleArray(Bitmap bmp) {
+        int w = bmp.getWidth();
+        int h = bmp.getHeight();
+        int[] pixels = new int[w * h];
+        bmp.getPixels(pixels, 0, w, 0, 0, w, h);
+        float[] gray = new float[pixels.length];
+        for (int i = 0; i < pixels.length; i++) {
+            int c = pixels[i];
+            int r = (c >> 16) & 0xFF;
+            int g = (c >> 8) & 0xFF;
+            int b = c & 0xFF;
+            gray[i] = 0.299f * r + 0.587f * g + 0.114f * b;
+        }
+        return gray;
+    }
+
+    private static double znccVerticalShift(float[] a, float[] b, int width, int height, int off, int stepX, int stepY) {
+        if (off == 0) {
+            return znccOverlap(a, b, width, height, 0, height, stepX, stepY);
+        }
+        if (off > 0) {
+            return znccOverlap(a, b, width, height, off, height - off, stepX, stepY);
+        } else {
+            int p = -off;
+            return znccOverlapShiftA(a, b, width, height, p, height - p, stepX, stepY);
+        }
+    }
+
+    private static double znccOverlap(float[] a, float[] b, int width, int height, int offStartB, int overlapH, int stepX, int stepY) {
+        if (overlapH <= 4) return -2.0;
+        double sumA = 0, sumB = 0, sumAA = 0, sumBB = 0, sumAB = 0;
+        int count = 0;
+        int startRowA = 0;
+        int startRowB = offStartB;
+        int endRowA = overlapH;
+        for (int yA = startRowA, yB = startRowB; yA < endRowA; yA += stepY, yB += stepY) {
+            int idxA = yA * width;
+            int idxB = yB * width;
+            for (int x = 0; x < width; x += stepX) {
+                double ia = a[idxA + x];
+                double ib = b[idxB + x];
+                sumA += ia;
+                sumB += ib;
+                sumAA += ia * ia;
+                sumBB += ib * ib;
+                sumAB += ia * ib;
+                count++;
+            }
+        }
+        if (count == 0) return -2.0;
+        double meanA = sumA / count;
+        double meanB = sumB / count;
+        double varA = sumAA / count - meanA * meanA;
+        double varB = sumBB / count - meanB * meanB;
+        double denom = varA * varB;
+        if (denom <= 1e-6) return -2.0;
+        double cov = sumAB / count - meanA * meanA - meanB * meanB + meanA * meanB; // corrected below
+        // Note: cov should be E[ab] - E[a]E[b]
+        cov = (sumAB / count) - meanA * meanB;
+        double ncc = cov / Math.sqrt(denom);
+        if (ncc > 1.0) ncc = 1.0; else if (ncc < -1.0) ncc = -1.0;
+        return ncc;
+    }
+
+    private static double znccOverlapShiftA(float[] a, float[] b, int width, int height, int offStartA, int overlapH, int stepX, int stepY) {
+        if (overlapH <= 4) return -2.0;
+        double sumA = 0, sumB = 0, sumAA = 0, sumBB = 0, sumAB = 0;
+        int count = 0;
+        int startRowA = offStartA;
+        int startRowB = 0;
+        int endRowA = offStartA + overlapH;
+        for (int yA = startRowA, yB = startRowB; yA < endRowA; yA += stepY, yB += stepY) {
+            int idxA = yA * width;
+            int idxB = yB * width;
+            for (int x = 0; x < width; x += stepX) {
+                double ia = a[idxA + x];
+                double ib = b[idxB + x];
+                sumA += ia;
+                sumB += ib;
+                sumAA += ia * ia;
+                sumBB += ib * ib;
+                sumAB += ia * ib;
+                count++;
+            }
+        }
+        if (count == 0) return -2.0;
+        double meanA = sumA / count;
+        double meanB = sumB / count;
+        double varA = sumAA / count - meanA * meanA;
+        double varB = sumBB / count - meanB * meanB;
+        double denom = varA * varB;
+        if (denom <= 1e-6) return -2.0;
+        double cov = (sumAB / count) - meanA * meanB;
+        double ncc = cov / Math.sqrt(denom);
+        if (ncc > 1.0) ncc = 1.0; else if (ncc < -1.0) ncc = -1.0;
+        return ncc;
+    }
+
+    private static Bitmap computeJoinAndGrow(Bitmap currentResult, Bitmap next, OffsetResult off, StitchOptions options) {
+        int width = currentResult.getWidth();
+        int height = next.getHeight();
+        int offset = clamp(off.offsetPx, -(height - 1), height - 1);
+
+        int overlapH = (offset >= 0) ? height - offset : height + offset;
+        overlapH = clamp(overlapH, 0, Math.min(height, currentResult.getHeight()));
+
+        int alignTopYInResult = currentResult.getHeight() - overlapH;
+        if (overlapH <= 0) {
+            Bitmap grown = Bitmap.createBitmap(width, currentResult.getHeight() + height, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(grown);
+            canvas.drawBitmap(currentResult, 0, 0, null);
+            canvas.drawBitmap(next, 0, currentResult.getHeight(), null);
+            return grown;
+        }
+
+        int seamRowInOverlap = findSeamRow(currentResult, next, alignTopYInResult, overlapH);
+        int blendBand = Math.max(0, options.blendBandPx);
+        int seamStartInResult = clamp(alignTopYInResult + seamRowInOverlap - blendBand / 2, 0, currentResult.getHeight());
+        int seamEndInResult = clamp(seamStartInResult + blendBand, 0, currentResult.getHeight());
+
+        int newHeight = Math.max(currentResult.getHeight(), alignTopYInResult + seamRowInOverlap + (height - seamRowInOverlap));
+        Bitmap grown = Bitmap.createBitmap(width, newHeight, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(grown);
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+        // draw current result
+        canvas.drawBitmap(currentResult, 0, 0, null);
+
+        // blend band
+        if (blendBand > 0 && seamStartInResult < seamEndInResult) {
+            int bandHeight = seamEndInResult - seamStartInResult;
+            int[] rowPrev = new int[width];
+            int[] rowNext = new int[width];
+            int[] blended = new int[width];
+            for (int y = 0; y < bandHeight; y++) {
+                float alpha = bandHeight <= 1 ? 1f : (y / (float) (bandHeight - 1));
+                int srcYPrev = seamStartInResult + y;
+                int srcYNext = srcYPrev - alignTopYInResult;
+                currentResult.getPixels(rowPrev, 0, width, 0, srcYPrev, width, 1);
+                next.getPixels(rowNext, 0, width, 0, srcYNext, width, 1);
+                blendRows(rowPrev, rowNext, alpha, blended);
+                grown.setPixels(blended, 0, width, 0, srcYPrev, width, 1);
+            }
+        }
+
+        // draw tail of next
+        int tailStartInNext = Math.max(0, seamRowInOverlap + (blendBand + 1) / 2);
+        int destYInResult = alignTopYInResult + tailStartInNext;
+        if (tailStartInNext < height && destYInResult < grown.getHeight()) {
+            int remainingH = Math.min(height - tailStartInNext, grown.getHeight() - destYInResult);
+            if (remainingH > 0) {
+                Bitmap tail = Bitmap.createBitmap(next, 0, tailStartInNext, width, remainingH);
+                canvas.drawBitmap(tail, 0, destYInResult, paint);
+            }
+        }
+        return grown;
+    }
+
+    private static int findSeamRow(Bitmap currentResult, Bitmap next, int alignTopYInResult, int overlapH) {
+        int width = currentResult.getWidth();
+        int x0 = Math.round(width * 0.1f);
+        int x1 = Math.max(x0 + 1, Math.round(width * 0.9f));
+        int[] rowPrev = new int[x1 - x0];
+        int[] rowNext = new int[x1 - x0];
+        long bestScore = Long.MAX_VALUE;
+        int bestRow = 0;
+        for (int y = 0; y < overlapH; y++) {
+            int srcYPrev = alignTopYInResult + y;
+            int srcYNext = y;
+            currentResult.getPixels(rowPrev, 0, x1 - x0, x0, srcYPrev, x1 - x0, 1);
+            next.getPixels(rowNext, 0, x1 - x0, x0, srcYNext, x1 - x0, 1);
+            long sum = 0L;
+            for (int i = 0; i < rowPrev.length; i++) {
+                sum += colorDiff(rowPrev[i], rowNext[i]);
+            }
+            if (sum < bestScore) {
+                bestScore = sum;
+                bestRow = y;
+            }
+        }
+        return bestRow;
+    }
+
+    private static int colorDiff(int a, int b) {
+        int ra = (a >> 16) & 0xFF;
+        int ga = (a >> 8) & 0xFF;
+        int ba = a & 0xFF;
+        int rb = (b >> 16) & 0xFF;
+        int gb = (b >> 8) & 0xFF;
+        int bb = b & 0xFF;
+        return Math.abs(ra - rb) + Math.abs(ga - gb) + Math.abs(ba - bb);
+    }
+
+    private static void blendRows(int[] prev, int[] next, float alpha, int[] out) {
+        float a = Math.max(0f, Math.min(1f, alpha));
+        float ia = 1f - a;
+        for (int i = 0; i < prev.length; i++) {
+            int p = prev[i];
+            int n = next[i];
+            int pr = (p >> 16) & 0xFF;
+            int pg = (p >> 8) & 0xFF;
+            int pb = p & 0xFF;
+            int nr = (n >> 16) & 0xFF;
+            int ng = (n >> 8) & 0xFF;
+            int nb = n & 0xFF;
+            int r = clamp(Math.round(pr * ia + nr * a), 0, 255);
+            int g = clamp(Math.round(pg * ia + ng * a), 0, 255);
+            int b = clamp(Math.round(pb * ia + nb * a), 0, 255);
+            out[i] = Color.rgb(r, g, b);
+        }
+    }
+
+    private static int clamp(int v, int lo, int hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
+}
+


### PR DESCRIPTION
Add `ScrollStitchUtil` for stitching scrollable screenshots using multi-scale ZNCC alignment and seam blending.

This utility provides a robust, no-third-party-library solution for vertically stitching a sequence of screenshots, implementing the recommended coarse-to-fine ZNCC-based offset estimation and seam blending strategy discussed in the conversation.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f089b25-18b9-4685-a804-8a96c4cfb478">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f089b25-18b9-4685-a804-8a96c4cfb478">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

